### PR TITLE
Fix backward compatibility for InferenceConfig schema

### DIFF
--- a/configs/test_run.yaml
+++ b/configs/test_run.yaml
@@ -50,12 +50,14 @@ gal:
     y_max: 0.7  # Fraction of image height (< 1) or pixels (>= 1)
 
 inference:
-  warmup: 100
-  samples: 100
-  chains: 1
-  dense_mass: false
+  method: nuts
+  nuts_config:
+    warmup: 100
+    samples: 100
+    chains: 1
+    dense_mass: false
+    map_init:
+      enabled: true
+      num_steps: 500
+      learning_rate: 0.01
   rng_seed: 0  # RNG seed for reproducibility
-  map_init:
-    enabled: true
-    num_steps: 500
-    learning_rate: 0.01

--- a/examples/shear_inference.py
+++ b/examples/shear_inference.py
@@ -55,16 +55,19 @@ config_dict = {
         },
     },
     "inference": {
-        "warmup": 500,
-        "samples": 1000,
-        "chains": 2,
-        "dense_mass": False,
-        "rng_seed": 42,
-        "map_init": {
-            "enabled": True,
-            "num_steps": 1000,
-            "learning_rate": 0.01,
+        "method": "nuts",
+        "nuts_config": {
+            "warmup": 500,
+            "samples": 1000,
+            "chains": 2,
+            "dense_mass": False,
+            "map_init": {
+                "enabled": True,
+                "num_steps": 1000,
+                "learning_rate": 0.01,
+            },
         },
+        "rng_seed": 42,
     },
     "data_path": None,           # None → generate synthetic data
     "output_path": "examples/output",
@@ -106,8 +109,8 @@ print("Probabilistic model built")
 rng_key = jax.random.PRNGKey(config.inference.rng_seed)
 engine = Inference(model=model_fn, config=config.inference)
 
-print(f"Running inference: {config.inference.warmup} warmup + "
-      f"{config.inference.samples} samples × {config.inference.chains} chains")
+print(f"Running inference: {config.inference.nuts_config.warmup} warmup + "
+      f"{config.inference.nuts_config.samples} samples × {config.inference.nuts_config.chains} chains")
 idata = engine.run(
     rng_key=rng_key,
     observed_data=observation.image,

--- a/shine/config.py
+++ b/shine/config.py
@@ -372,19 +372,38 @@ class InferenceConfig(BaseModel):
     Each method reads its own config block; the others are ignored.
     When a method's config block is None, defaults are applied.
 
+    Backward Compatibility:
+    This class also supports the legacy flat structure where NUTS parameters
+    (warmup, samples, chains, dense_mass, map_init) are provided directly
+    at the inference level. These will be automatically migrated to the new
+    hierarchical structure (nuts_config).
+
     Attributes:
         method: Inference method ("nuts", "map", or "vi").
         nuts_config: Configuration for NUTS/MCMC (used when method="nuts").
         map_config: Configuration for MAP estimation (used when method="map").
         vi_config: Configuration for Variational Inference (used when method="vi").
         rng_seed: Random number generator seed for reproducibility (default 0).
+        warmup: [DEPRECATED] Use nuts_config.warmup instead.
+        samples: [DEPRECATED] Use nuts_config.samples instead.
+        chains: [DEPRECATED] Use nuts_config.chains instead.
+        dense_mass: [DEPRECATED] Use nuts_config.dense_mass instead.
+        map_init: [DEPRECATED] Use nuts_config.map_init instead.
     """
+
 
     method: Literal["nuts", "map", "vi"] = "nuts"
     nuts_config: Optional[NUTSConfig] = None
     map_config: Optional[MAPConfig] = None
     vi_config: Optional[VIConfig] = None
     rng_seed: int = 0
+
+    # Backward compatibility fields (legacy flat structure)
+    warmup: Optional[int] = None
+    samples: Optional[int] = None
+    chains: Optional[int] = None
+    dense_mass: Optional[bool] = None
+    map_init: Optional[MAPConfig] = None
 
     @field_validator("rng_seed")
     @classmethod
@@ -393,6 +412,51 @@ class InferenceConfig(BaseModel):
         if v < 0:
             raise ValueError(f"RNG seed must be non-negative, got {v}")
         return v
+
+    @model_validator(mode="after")
+    def migrate_legacy_config(self) -> "InferenceConfig":
+        """Migrate legacy flat config to hierarchical structure.
+
+        If any of the legacy fields (warmup, samples, chains, dense_mass, map_init)
+        are provided, automatically create a NUTSConfig from them and clear the
+        legacy fields to avoid confusion.
+        """
+        # Check if any legacy fields are provided
+        has_legacy = any(
+            [
+                self.warmup is not None,
+                self.samples is not None,
+                self.chains is not None,
+                self.dense_mass is not None,
+                self.map_init is not None,
+            ]
+        )
+
+        if has_legacy:
+            # If nuts_config is already provided, raise an error
+            if self.nuts_config is not None:
+                raise ValueError(
+                    "Cannot specify both legacy flat config (warmup, samples, etc.) "
+                    "and nuts_config. Please use only one format."
+                )
+
+            # Create NUTSConfig from legacy fields, using defaults where not specified
+            self.nuts_config = NUTSConfig(
+                warmup=self.warmup if self.warmup is not None else 500,
+                samples=self.samples if self.samples is not None else 1000,
+                chains=self.chains if self.chains is not None else 1,
+                dense_mass=self.dense_mass if self.dense_mass is not None else False,
+                map_init=self.map_init,
+            )
+
+            # Clear legacy fields to avoid confusion
+            self.warmup = None
+            self.samples = None
+            self.chains = None
+            self.dense_mass = None
+            self.map_init = None
+
+        return self
 
 
 class ShineConfig(BaseModel):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -296,6 +296,81 @@ class TestInferenceConfig:
         config = InferenceConfig(rng_seed=42)
         assert config.method == "nuts"
 
+    def test_inference_config_legacy_flat_structure(self):
+        """Test backward compatibility with legacy flat config structure."""
+        # Old-style config with flat structure
+        config = InferenceConfig(
+            warmup=500,
+            samples=1000,
+            chains=2,
+            dense_mass=True,
+            rng_seed=42,
+        )
+
+        # Should be migrated to nuts_config
+        assert config.nuts_config is not None
+        assert config.nuts_config.warmup == 500
+        assert config.nuts_config.samples == 1000
+        assert config.nuts_config.chains == 2
+        assert config.nuts_config.dense_mass is True
+        assert config.rng_seed == 42
+
+        # Legacy fields should be cleared
+        assert config.warmup is None
+        assert config.samples is None
+        assert config.chains is None
+        assert config.dense_mass is None
+
+    def test_inference_config_legacy_with_map_init(self):
+        """Test backward compatibility with legacy config including map_init."""
+        map_cfg = MAPConfig(enabled=True, num_steps=1000, learning_rate=0.01)
+        config = InferenceConfig(
+            warmup=500,
+            samples=1000,
+            chains=2,
+            dense_mass=False,
+            map_init=map_cfg,
+            rng_seed=42,
+        )
+
+        # Should be migrated to nuts_config
+        assert config.nuts_config is not None
+        assert config.nuts_config.warmup == 500
+        assert config.nuts_config.samples == 1000
+        assert config.nuts_config.chains == 2
+        assert config.nuts_config.dense_mass is False
+        assert config.nuts_config.map_init is not None
+        assert config.nuts_config.map_init.enabled is True
+        assert config.nuts_config.map_init.num_steps == 1000
+
+        # Legacy map_init should be cleared
+        assert config.map_init is None
+
+    def test_inference_config_legacy_partial_fields(self):
+        """Test backward compatibility with partial legacy fields uses defaults."""
+        # Only provide some legacy fields
+        config = InferenceConfig(warmup=300, samples=500)
+
+        # Should use defaults for missing fields
+        assert config.nuts_config is not None
+        assert config.nuts_config.warmup == 300
+        assert config.nuts_config.samples == 500
+        assert config.nuts_config.chains == 1  # default
+        assert config.nuts_config.dense_mass is False  # default
+
+    def test_inference_config_legacy_and_new_conflict(self):
+        """Test that mixing legacy and new config raises error."""
+        nuts_cfg = NUTSConfig(warmup=200, samples=400)
+        with pytest.raises(
+            ValueError,
+            match="Cannot specify both legacy flat config .* and nuts_config",
+        ):
+            InferenceConfig(
+                warmup=500,  # legacy
+                samples=1000,  # legacy
+                nuts_config=nuts_cfg,  # new
+            )
+
 
 class TestShineConfig:
     """Test full ShineConfig."""
@@ -403,5 +478,54 @@ class TestConfigHandler:
             assert config.gal.flux.mean == 1000.0
             assert isinstance(config.gal.half_light_radius, DistributionConfig)
             assert config.gal.half_light_radius.min == 0.5
+        finally:
+            Path(tmp_path).unlink()
+
+    def test_load_config_with_legacy_inference(self):
+        """Test loading configuration with legacy flat inference structure."""
+        config_data = {
+            "image": {
+                "pixel_scale": 0.2,
+                "size_x": 32,
+                "size_y": 32,
+                "noise": {"type": "Gaussian", "sigma": 1.0},
+            },
+            "psf": {"type": "Gaussian", "sigma": 1.0},
+            "gal": {
+                "type": "Exponential",
+                "flux": 1000.0,
+                "half_light_radius": 1.0,
+                "shear": {"type": "G1G2", "g1": 0.01, "g2": -0.02},
+            },
+            "inference": {
+                # Legacy flat structure
+                "warmup": 500,
+                "samples": 1000,
+                "chains": 2,
+                "dense_mass": False,
+                "rng_seed": 42,
+                "map_init": {
+                    "enabled": True,
+                    "num_steps": 1000,
+                    "learning_rate": 0.01,
+                },
+            },
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tmp:
+            yaml.dump(config_data, tmp)
+            tmp_path = tmp.name
+
+        try:
+            config = ConfigHandler.load(tmp_path)
+            # Should be automatically migrated to new structure
+            assert config.inference.nuts_config is not None
+            assert config.inference.nuts_config.warmup == 500
+            assert config.inference.nuts_config.samples == 1000
+            assert config.inference.nuts_config.chains == 2
+            assert config.inference.nuts_config.dense_mass is False
+            assert config.inference.nuts_config.map_init is not None
+            assert config.inference.nuts_config.map_init.enabled is True
+            assert config.inference.rng_seed == 42
         finally:
             Path(tmp_path).unlink()


### PR DESCRIPTION
## Summary

Resolves #13 by adding backward compatibility to the `InferenceConfig` class. The example script `examples/shear_inference.py` now works with both the old flat config structure and the new hierarchical structure.

## Changes

- Added optional legacy fields to `InferenceConfig` (`warmup`, `samples`, `chains`, `dense_mass`, `map_init`)
- Implemented `migrate_legacy_config` validator that automatically migrates old configs to new hierarchical structure
- Added comprehensive tests for backward compatibility
- Ensured mixing both formats raises a clear error

## Testing

Added tests covering:
- Full legacy config migration
- Legacy config with MAP initialization
- Partial legacy fields with defaults
- Error when mixing both formats
- Loading legacy YAML config

---

Generated with [Claude Code](https://claude.ai/code)