### PR TITLE
Refactor priors to use explicit GalaxyConfig with catalog-centered distributions

### DIFF
--- a/configs/euclid_vis.yaml
+++ b/configs/euclid_vis.yaml
@@ -2,6 +2,11 @@
 #
 # Points to the bundled test data in data/EUC_VIS_SWL/.
 # Selects the 600 brightest sources and runs MAP inference for quick testing.
+#
+# The `gal:` section specifies the probabilistic model: galaxy profile type,
+# which parameters are latent variables (distributions) vs fixed, and what
+# priors are used.  Parameters with `center: catalog` use per-source catalog
+# values as the distribution location at runtime.
 
 data:
   exposure_paths:
@@ -26,12 +31,31 @@ sources:
   det_quality_exclude_mask: 0x78C
   max_sources: 600
 
-priors:
-  shear_prior_sigma: 0.05
-  flux_prior_log_sigma: 0.5
-  hlr_prior_log_sigma: 0.3
-  ellipticity_prior_sigma: 0.3
-  position_prior_sigma: 0.05
+# Galaxy model specification — the probabilistic model is explicit here.
+# Each parameter is either a fixed value or a distribution (= latent variable).
+gal:
+  type: Exponential
+
+  shear:
+    type: G1G2
+    g1: {type: Normal, mean: 0.0, sigma: 0.05}
+    g2: {type: Normal, mean: 0.0, sigma: 0.05}
+
+  # Catalog-centered priors: center="catalog" means the LogNormal median
+  # is set to each source's catalog value at runtime.
+  flux: {type: LogNormal, center: catalog, sigma: 0.5}
+  half_light_radius: {type: LogNormal, center: catalog, sigma: 0.3}
+
+  ellipticity:
+    type: E1E2
+    e1: {type: Normal, mean: 0.0, sigma: 0.3}
+    e2: {type: Normal, mean: 0.0, sigma: 0.3}
+
+  # Position offsets from catalog positions (in arcsec)
+  position:
+    type: Offset
+    dx: {type: Normal, mean: 0.0, sigma: 0.05}
+    dy: {type: Normal, mean: 0.0, sigma: 0.05}
 
 inference:
   method: map

--- a/docs/api/config.md
+++ b/docs/api/config.md
@@ -4,8 +4,12 @@ Configuration handling with Pydantic models.
 
 Parses YAML configuration files and validates all parameters. Distribution
 parameters (Normal, LogNormal, Uniform) are automatically treated as latent
-variables for Bayesian inference. The `InferenceConfig` supports three
-inference methods (NUTS, MAP, VI) with method-specific config blocks
-(`NUTSConfig`, `MAPConfig`, `VIConfig`).
+variables for Bayesian inference. Distributions can use `center: "catalog"` to
+resolve their location parameter from per-source catalog data at runtime.
+Position priors support both `Uniform` (absolute pixel positions) and `Offset`
+(small offsets from catalog positions) modes.
+
+The `InferenceConfig` supports three inference methods (NUTS, MAP, VI) with
+method-specific config blocks (`NUTSConfig`, `MAPConfig`, `VIConfig`).
 
 ::: shine.config

--- a/docs/api/prior_utils.md
+++ b/docs/api/prior_utils.md
@@ -1,0 +1,10 @@
+# shine.prior_utils
+
+Shared prior-parsing utilities for SHINE scene builders.
+
+Converts `DistributionConfig` entries (or fixed numeric values) into NumPyro
+sample sites. Supports catalog-centered priors via the `center="catalog"`
+mechanism, where the distribution location parameter comes from per-source
+catalog data at runtime.
+
+::: shine.prior_utils

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ nav:
     - GPU-Batched Inference: validation/batched.md
   - API Reference:
     - shine.config: api/config.md
+    - shine.prior_utils: api/prior_utils.md
     - shine.scene: api/scene.md
     - shine.inference: api/inference.md
     - shine.data: api/data.md

--- a/shine/euclid/__init__.py
+++ b/shine/euclid/__init__.py
@@ -7,14 +7,12 @@ Euclid VIS quadrant-level shear inference.
 from shine.euclid.config import (
     EuclidDataConfig,
     EuclidInferenceConfig,
-    PriorConfig,
     SourceSelectionConfig,
 )
 
 __all__ = [
     "EuclidDataConfig",
     "SourceSelectionConfig",
-    "PriorConfig",
     "EuclidInferenceConfig",
     "EuclidPSFModel",
     "EuclidExposure",

--- a/shine/prior_utils.py
+++ b/shine/prior_utils.py
@@ -1,0 +1,75 @@
+"""Shared prior-parsing utilities for SHINE scene builders.
+
+Converts :class:`~shine.config.DistributionConfig` entries (or fixed
+numeric values) into NumPyro sample sites.  Supports catalog-centered
+priors via the ``center="catalog"`` mechanism.
+"""
+
+from typing import Optional, Union
+
+import jax.numpy as jnp
+import numpyro
+import numpyro.distributions as dist
+
+from shine.config import DistributionConfig
+
+
+def parse_prior(
+    name: str,
+    param_config: Union[float, int, DistributionConfig],
+    catalog_values: Optional[jnp.ndarray] = None,
+) -> Union[float, jnp.ndarray]:
+    """Create a NumPyro sample site from a config entry, or return a fixed value.
+
+    Args:
+        name: Parameter name for the NumPyro sample site.
+        param_config: Either a fixed numeric value or a
+            :class:`DistributionConfig` describing the prior distribution.
+        catalog_values: Per-source catalog values used as the location
+            parameter when ``param_config.center == "catalog"``.  Required
+            when catalog-centered priors are used; ignored otherwise.
+
+    Returns:
+        Sampled value(s) from the distribution, or the fixed value.
+
+    Raises:
+        ValueError: If the distribution type is not recognized, or if
+            ``center="catalog"`` is used but *catalog_values* is ``None``.
+    """
+    if isinstance(param_config, (float, int)):
+        return float(param_config)
+
+    catalog_centered = getattr(param_config, "center", None) == "catalog"
+
+    if catalog_centered and catalog_values is None:
+        raise ValueError(
+            f"Parameter '{name}' has center='catalog' but no catalog_values "
+            f"were provided"
+        )
+
+    if param_config.type == "Normal":
+        if catalog_centered:
+            return numpyro.sample(
+                name, dist.Normal(catalog_values, param_config.sigma)
+            )
+        return numpyro.sample(
+            name, dist.Normal(param_config.mean, param_config.sigma)
+        )
+
+    if param_config.type == "LogNormal":
+        if catalog_centered:
+            return numpyro.sample(
+                name,
+                dist.LogNormal(jnp.log(catalog_values), param_config.sigma),
+            )
+        return numpyro.sample(
+            name,
+            dist.LogNormal(jnp.log(param_config.mean), param_config.sigma),
+        )
+
+    if param_config.type == "Uniform":
+        return numpyro.sample(
+            name, dist.Uniform(param_config.min, param_config.max)
+        )
+
+    raise ValueError(f"Unknown distribution type: '{param_config.type}'")

--- a/shine/scene.py
+++ b/shine/scene.py
@@ -8,6 +8,7 @@ import numpyro.distributions as dist
 
 from shine import galaxy_utils
 from shine.config import DistributionConfig, ShineConfig
+from shine.prior_utils import parse_prior
 
 # Default position prior bounds as fraction of image size
 _DEFAULT_POS_MIN_FRAC = 0.3
@@ -33,10 +34,13 @@ class SceneBuilder:
         """
         self.config = config
 
+    @staticmethod
     def _parse_prior(
-        self, name: str, param_config: Union[float, int, DistributionConfig]
+        name: str, param_config: Union[float, int, DistributionConfig]
     ) -> float:
         """Create a NumPyro sample site from config, or return a fixed value.
+
+        Thin wrapper around :func:`shine.prior_utils.parse_prior`.
 
         Args:
             name: Parameter name for NumPyro sampling.
@@ -48,22 +52,7 @@ class SceneBuilder:
         Raises:
             ValueError: If the distribution type is not recognized.
         """
-        if isinstance(param_config, (float, int)):
-            return float(param_config)
-
-        if param_config.type == "Normal":
-            return numpyro.sample(
-                name, dist.Normal(param_config.mean, param_config.sigma)
-            )
-        if param_config.type == "LogNormal":
-            return numpyro.sample(
-                name, dist.LogNormal(jnp.log(param_config.mean), param_config.sigma)
-            )
-        if param_config.type == "Uniform":
-            return numpyro.sample(
-                name, dist.Uniform(param_config.min, param_config.max)
-            )
-        raise ValueError(f"Unknown distribution type: '{param_config.type}'")
+        return parse_prior(name, param_config)
 
     @staticmethod
     def _resolve_bound(

--- a/tests/test_prior_utils.py
+++ b/tests/test_prior_utils.py
@@ -1,0 +1,118 @@
+"""Tests for shine.prior_utils module."""
+
+import jax.numpy as jnp
+import numpyro
+import numpyro.handlers as handlers
+import pytest
+from jax import random
+
+from shine.config import DistributionConfig
+from shine.prior_utils import parse_prior
+
+
+class TestParsepriorFixedValues:
+    """Test parse_prior with fixed numeric values."""
+
+    def test_float_passthrough(self):
+        """Fixed float values are returned directly."""
+        assert parse_prior("x", 1.5) == 1.5
+
+    def test_int_passthrough(self):
+        """Fixed int values are returned as float."""
+        result = parse_prior("x", 3)
+        assert result == 3.0
+        assert isinstance(result, float)
+
+
+class TestParsePriorDistributions:
+    """Test parse_prior with standard distribution configs."""
+
+    def test_normal_distribution(self):
+        """Normal distribution creates a sample site with correct params."""
+        cfg = DistributionConfig(type="Normal", mean=1.0, sigma=0.5)
+
+        def model():
+            return parse_prior("x", cfg)
+
+        rng = random.PRNGKey(0)
+        trace = handlers.trace(handlers.seed(model, rng)).get_trace()
+        assert "x" in trace
+        assert trace["x"]["type"] == "sample"
+
+    def test_lognormal_distribution(self):
+        """LogNormal distribution creates a sample site."""
+        cfg = DistributionConfig(type="LogNormal", mean=100.0, sigma=0.5)
+
+        def model():
+            return parse_prior("x", cfg)
+
+        rng = random.PRNGKey(0)
+        trace = handlers.trace(handlers.seed(model, rng)).get_trace()
+        assert "x" in trace
+        # LogNormal samples are always positive
+        assert trace["x"]["value"] > 0
+
+    def test_uniform_distribution(self):
+        """Uniform distribution creates a sample site."""
+        cfg = DistributionConfig(type="Uniform", min=0.0, max=10.0)
+
+        def model():
+            return parse_prior("x", cfg)
+
+        rng = random.PRNGKey(0)
+        trace = handlers.trace(handlers.seed(model, rng)).get_trace()
+        assert "x" in trace
+        val = float(trace["x"]["value"])
+        assert 0.0 <= val <= 10.0
+
+    def test_unknown_distribution_raises(self):
+        """Unknown distribution type raises ValueError."""
+        cfg = DistributionConfig.model_construct(type="Cauchy", sigma=1.0)
+        with pytest.raises(ValueError, match="Unknown distribution type"):
+            parse_prior("x", cfg)
+
+
+class TestParsePriorCatalogCentered:
+    """Test parse_prior with center='catalog' priors."""
+
+    def test_lognormal_catalog_centered(self):
+        """LogNormal with center='catalog' uses catalog values as median."""
+        cfg = DistributionConfig(type="LogNormal", center="catalog", sigma=0.5)
+        catalog = jnp.array([100.0, 200.0, 300.0])
+
+        def model():
+            with numpyro.plate("sources", 3):
+                return parse_prior("flux", cfg, catalog_values=catalog)
+
+        rng = random.PRNGKey(0)
+        trace = handlers.trace(handlers.seed(model, rng)).get_trace()
+        assert "flux" in trace
+        assert trace["flux"]["value"].shape == (3,)
+        # All samples should be positive (LogNormal)
+        assert jnp.all(trace["flux"]["value"] > 0)
+
+    def test_normal_catalog_centered(self):
+        """Normal with center='catalog' uses catalog values as mean."""
+        cfg = DistributionConfig(type="Normal", center="catalog", sigma=0.1)
+        catalog = jnp.array([1.0, 2.0, 3.0])
+
+        def model():
+            with numpyro.plate("sources", 3):
+                return parse_prior("pos", cfg, catalog_values=catalog)
+
+        rng = random.PRNGKey(0)
+        trace = handlers.trace(handlers.seed(model, rng)).get_trace()
+        assert "pos" in trace
+        assert trace["pos"]["value"].shape == (3,)
+
+    def test_catalog_centered_without_values_raises(self):
+        """center='catalog' without catalog_values raises ValueError."""
+        cfg = DistributionConfig(type="LogNormal", center="catalog", sigma=0.5)
+        with pytest.raises(ValueError, match="no catalog_values"):
+            parse_prior("flux", cfg)
+
+    def test_catalog_centered_none_values_raises(self):
+        """center='catalog' with catalog_values=None raises ValueError."""
+        cfg = DistributionConfig(type="LogNormal", center="catalog", sigma=0.5)
+        with pytest.raises(ValueError, match="no catalog_values"):
+            parse_prior("flux", cfg, catalog_values=None)


### PR DESCRIPTION
## Summary

This PR replaces the hard-coded `PriorConfig` with an explicit, flexible `GalaxyConfig` that specifies the full probabilistic model (profile type, parameters, and priors) in configuration. It introduces support for **catalog-centered priors** via a new `center="catalog"` mechanism in `DistributionConfig`, allowing per-source catalog values to be used as distribution locations at runtime.

## Key Changes

- **New `shine/prior_utils.py`**: Shared prior-parsing utility that converts `DistributionConfig` entries (or fixed numeric values) into NumPyro sample sites. Supports catalog-centered priors by accepting optional `catalog_values` parameter.

- **Enhanced `DistributionConfig`**: 
  - Added `center: Optional[str]` field to support `center="catalog"` mode
  - When `center="catalog"`, the `mean` parameter is optional and ignored; per-source catalog values are used as the distribution location instead
  - Updated validation to allow omitting `mean` when `center="catalog"` is set, but still require `sigma`

- **New `PositionConfig` "Offset" mode**:
  - Added `dx` and `dy` fields to support position offsets (e.g., from catalog positions)
  - Each can be a fixed value or a `DistributionConfig`
  - Existing "Uniform" mode unchanged

- **Replaced `PriorConfig` with `GalaxyConfig`**:
  - Removed `shine.euclid.config.PriorConfig` (which only held sigma values)
  - `EuclidInferenceConfig.priors` → `EuclidInferenceConfig.gal` (a `GalaxyConfig`)
  - Added `_default_euclid_galaxy_config()` factory that builds the default Euclid model matching the previously hard-coded priors

- **Updated `MultiExposureScene._sample_parameters()`**:
  - Now reads priors from `self.config.gal` instead of `self.config.priors`
  - Uses `parse_prior()` to handle both fixed values and distributions
  - Passes `catalog_values` for flux and half-light radius (catalog-centered LogNormal priors)
  - Conditionally samples ellipticity and position offsets based on config

- **Updated `shine.scene.Scene._parse_prior()`**: Now a static method that delegates to `parse_prior()` from `prior_utils`.

- **Configuration file (`configs/euclid_vis.yaml`)**:
  - Replaced `priors:` section with explicit `gal:` section
  - Shows full galaxy model specification: profile type, shear/ellipticity/position distributions, and catalog-centered priors

- **Comprehensive test coverage** (`tests/test_prior_utils.py`):
  - Tests for fixed values, standard distributions (Normal, LogNormal, Uniform)
  - Tests for catalog-centered priors with and without catalog values
  - Error cases (unknown distribution type, missing catalog values)

## Notable Implementation Details

- **Catalog-centered LogNormal**: When `center="catalog"`, the median is set to each source's catalog value; internally `log(catalog_value)` is used as the log-space location parameter.
- **Backward compatibility**: The default `GalaxyConfig` factory reproduces the exact priors that were previously hard-coded, ensuring existing inference results are reproducible.
- **Explicit probabilistic model**: The galaxy model is now fully specified in YAML, making the prior structure and parameter choices transparent and easily modifiable.

https://claude.ai/code/session_01Cfk98zXxwLMsDoGuf5L9Gp